### PR TITLE
added timing mechanism to time proofreading

### DIFF
--- a/synanno/__init__.py
+++ b/synanno/__init__.py
@@ -32,7 +32,7 @@ progress_bar_status = {"status":"Loading Source File", "percent":0}
 
 # document the time needed for proofreading
 global proofread_time
-proofread_time = {"start":None,"finish":None,"difference":None}
+proofread_time = {"start_grid":None,"finish_grid":None,"difference_grid":None, "start_categorize":None,"finish_categorize":None,"difference_categorize":None}
 
 from synanno.routes import annotation, finish, opendata, categorize
 

--- a/synanno/routes/annotation.py
+++ b/synanno/routes/annotation.py
@@ -62,8 +62,8 @@ def set_data(data_name='synAnno.json'):
 @app.route('/annotation/<int:page>')
 def annotation(page=0):
     global grid_opacity
-    if synanno.proofread_time["start"] is None:
-        synanno.proofread_time["start"] = datetime.datetime.now()
+    if synanno.proofread_time["start_grid"] is None:
+        synanno.proofread_time["start_grid"] = datetime.datetime.now()
     return render_template('annotation.html', images=session.get('data')[page], page=page, n_pages=session.get('n_pages'), grid_opacity=grid_opacity)
 
 @app.route('/set_grid_opacity', methods=['POST'])

--- a/synanno/routes/categorize.py
+++ b/synanno/routes/categorize.py
@@ -7,12 +7,21 @@ from flask_cors import cross_origin
 
 import json
 
+# for access to the timing variable
+import synanno
+import datetime
+
 
 global delete_fp
 delete_fp = False
 
 @app.route('/categorize')
 def categorize():
+    if synanno.proofread_time["finish_grid"] is None:
+        synanno.proofread_time["finish_grid"] = datetime.datetime.now()
+        synanno.proofread_time["difference_grid"] = synanno.proofread_time["finish_grid"] - synanno.proofread_time["start_grid"]
+    if synanno.proofread_time["start_categorize"] is None:
+        synanno.proofread_time["start_categorize"] = datetime.datetime.now()
     return render_template('categorize.html', pages=session.get('data'))
 
 

--- a/synanno/routes/finish.py
+++ b/synanno/routes/finish.py
@@ -17,10 +17,9 @@ import json
 
 @app.route('/final_page')
 def final_page():
-    if synanno.proofread_time["finish"] is None:
-        synanno.proofread_time["finish"] = datetime.datetime.now()
-        synanno.proofread_time["difference"] = synanno.proofread_time["finish"] - synanno.proofread_time["start"]
-        print("synanno.proofread_time[difference]: ", synanno.proofread_time["difference"])
+    if synanno.proofread_time["finish_categorize"] is None:
+        synanno.proofread_time["finish_categorize"] = datetime.datetime.now()
+        synanno.proofread_time["difference_categorize"] = synanno.proofread_time["finish_categorize"] - synanno.proofread_time["start_categorize"]
     return render_template('exportdata.html')
 
 @app.route('/export')
@@ -43,6 +42,9 @@ def reset():
 
     # reset progress bar 
     synanno.progress_bar_status = {"status":"Loading Source File", "percent":0}
+
+    # reset time
+    synanno.proofread_time = dict.fromkeys(synanno.proofread_time, None)
 
     # pop all the session content.
     for key in list(session.keys()):


### PR DESCRIPTION
solves #41 

Added a timing mechanism to time the proofreading

- Start running a clock as soon as the user opens the annotation view for the first time
- Stop the clock when the user opens the categorization view and start a new clock for the categorization
- Stop the clock when the user opens the "finish" view for the first time

The information is added to the JSON as follows:  `{{"Data":[...],"Proofread Time": {"start_grid": "2022-06-06T09:53:01.429375", "finish_grid": "2022-06-06T09:53:09.608887", "difference_grid": "0:00:08.179512", "start_categorize": "2022-06-06T09:53:09.608898", "finish_categorize": "2022-06-06T09:53:13.366315", "difference_categorize": "0:00:03.757417"}}`