### PR TITLE
Implement New Mask Layout and Synapse ID Point Selection

### DIFF
--- a/synanno/__init__.py
+++ b/synanno/__init__.py
@@ -108,8 +108,9 @@ global df_metadata
 
 # Define the column names
 columns = ['Page', 'Image_Index', 'GT', 'EM', 'Label', 'Annotated', 'Error_Description',
-           'Middle_Slice', 'Original_Bbox', 'cz0', 'cy0', 'cx0', 'crop_size_x',
-           'crop_size_y', 'crop_size_z', 'Adjusted_Bbox', 'Padding']
+           'Middle_Slice', 'Original_Bbox', 'cz0', 'cy0', 'cx0', 'pre_pt_z', 
+           'pre_pt_x', 'pre_pt_y', 'post_pt_y', 'post_pt_z', 'post_pt_x',
+           'crop_size_x', 'crop_size_y', 'crop_size_z', 'Adjusted_Bbox', 'Padding']
 
 # create an empty DataFrame with these columns
 df_metadata = pd.DataFrame(columns=columns)

--- a/synanno/backend/utils.py
+++ b/synanno/backend/utils.py
@@ -1,5 +1,5 @@
 from __future__ import print_function, division
-from typing import Dict, Callable
+from typing import Dict, Callable, Tuple
 
 
 import os
@@ -109,3 +109,41 @@ def submit_with_retry(executor: concurrent.futures.Executor, func: Callable[[dic
             print(f"Attempt {attempt+1} failed with error: {str(e)}")
     print(f"All {retries} attempts failed.")
     return None
+
+
+from typing import Tuple
+import numpy as np
+
+def draw_cylinder(image: np.ndarray, center_x: int, center_y: int, center_z: int, radius: int, color_1: Tuple[int, int, int], color_2: Tuple[int, int, int]) -> np.ndarray:
+    """
+    Function to draw a cylinder in a 4D numpy array. The color of the cylinder changes based on the distance from the center_z.
+    
+    Parameters:
+    image (np.ndarray): Input 4D numpy array.
+    center_x (int): X-coordinate of the cylinder center.
+    center_y (int): Y-coordinate of the cylinder center.
+    center_z (int): Z-coordinate of the cylinder center.
+    radius (int): Radius of the cylinder.
+    color_1 (Tuple[int, int, int]): RGB color of the circle in the center_z layer.
+    color_2 (Tuple[int, int, int]): RGB color of the circles in the other layers.
+    
+    Returns:
+    np.ndarray: 4D numpy array with the cylinder drawn.
+    """
+
+    z_len, y_len, x_len, _ = image.shape
+
+    # Create coordinate grid
+    Y, X = np.meshgrid(np.arange(y_len), np.arange(x_len), indexing='ij')
+
+    # Create 3D mask for the cylinder
+    mask_cylinder = (X - center_x) ** 2 + (Y - center_y) ** 2 <= radius ** 2
+
+    for i in range(z_len):
+        if i != center_z:
+            image[i, mask_cylinder, :] = color_2
+        else:
+            image[i, mask_cylinder, :] = color_1
+            
+    return image
+

--- a/synanno/routes/opendata.py
+++ b/synanno/routes/opendata.py
@@ -253,7 +253,9 @@ def get_instance() -> Dict[str, object]:
     page = int(request.form['page'])
     index = int(request.form['data_id'])
 
-    custom_mask_path = None
+    custom_mask_path_curve = None
+    custom_mask_path_pre = None
+    custom_mask_path_post = None
 
     # when first opening a instance modal view
     if load == 'full':
@@ -273,14 +275,20 @@ def get_instance() -> Dict[str, object]:
             base_mask_path = str(request.form['base_mask_path'])
             if base_mask_path:
                 coordinates = '_'.join(list(map(str,data["Adjusted_Bbox"])))
-                path = os.path.join(base_mask_path, 'idx_' + str(data["Image_Index"]) + '_ms_' +  str(data["Middle_Slice"]) + '_cor_' + coordinates + '.png')
-                if os.path.exists('./synanno' + path):
-                    custom_mask_path = path
+                path_curve = os.path.join(base_mask_path, 'curve_idx_' + str(data["Image_Index"]) + '_slice_' +  str(data["Middle_Slice"]) + '_cor_' + coordinates + '.png')
+                path_circle_pre = os.path.join(base_mask_path, 'circlePre_idx_' + str(data["Image_Index"]) + '_slice_' +  str(data["Middle_Slice"]) + '_cor_' + coordinates + '.png')
+                path_circle_post = os.path.join(base_mask_path, 'circlePost_idx_' + str(data["Image_Index"]) + '_slice_' +  str(data["Middle_Slice"]) + '_cor_' + coordinates + '.png')
+                if os.path.exists('./synanno' + path_curve):
+                    custom_mask_path_curve = path_curve
+                if os.path.exists('./synanno' + path_circle_pre):
+                    custom_mask_path_pre = path_circle_pre
+                if os.path.exists('./synanno' + path_circle_post):
+                    custom_mask_path_post = path_circle_post
 
         data = json.dumps(data)
 
         final_json = jsonify(data=data, slices_len=slices_len, halflen=middle_slice,
-                             range_min=range_min, host=app.config['IP'], port=app.config['PORT'], custom_mask_path=custom_mask_path)
+                             range_min=range_min, host=app.config['IP'], port=app.config['PORT'], custom_mask_path_curve=custom_mask_path_curve, custom_mask_path_pre=custom_mask_path_pre, custom_mask_path_post=custom_mask_path_post)
 
     # when changing the depicted slice with in the modal view
     elif load == 'single':
@@ -294,12 +302,18 @@ def get_instance() -> Dict[str, object]:
                 # check if file exists
                 if viewed_instance_slice:
                     coordinates = '_'.join(list(map(str,data["Adjusted_Bbox"])))
-                    path = os.path.join(base_mask_path, 'idx_' + str(data["Image_Index"]) + '_ms_' +  str(viewed_instance_slice) + '_cor_' + coordinates + '.png')
-                    if os.path.exists('./synanno' + path):
-                        custom_mask_path = path
+                    path_curve = os.path.join(base_mask_path, 'curve_idx_' + str(data["Image_Index"]) + '_slice_' +  str(viewed_instance_slice) + '_cor_' + coordinates + '.png')
+                    path_circle_pre = os.path.join(base_mask_path, 'circlePre_idx_' + str(data["Image_Index"]) + '_slice_' +  str(viewed_instance_slice) + '_cor_' + coordinates + '.png')
+                    path_circle_post = os.path.join(base_mask_path, 'circlePost_idx_' + str(data["Image_Index"]) + '_slice_' +  str(viewed_instance_slice) + '_cor_' + coordinates + '.png')
+                    if os.path.exists('./synanno' + path_curve):
+                        custom_mask_path_curve = path_curve
+                    if os.path.exists('./synanno' + path_circle_pre):
+                        custom_mask_path_pre = path_circle_pre
+                    if os.path.exists('./synanno' + path_circle_post):
+                        custom_mask_path_post = path_circle_post
 
         data = json.dumps(data)
-        return jsonify(data=data, custom_mask_path=custom_mask_path)
+        return jsonify(data=data, custom_mask_path_curve=custom_mask_path_curve, custom_mask_path_pre=custom_mask_path_pre, custom_mask_path_post=custom_mask_path_post)
 
     return final_json
 

--- a/synanno/static/draw.js
+++ b/synanno/static/draw.js
@@ -31,18 +31,15 @@ $(document).ready(function () {
     var pointsQBez = []
 
     // init thickness
-    var thickness = 10
+    var thickness = 20
 
     // define colors
-    const turquoise = 'rgba(51, 255, 240)';
-    const pink = 'rgba(252, 14, 249)';
+    const turquoise = 'rgba(51, 255, 240, 0.7)';
 
     // set polarity default
-    var color_1 = turquoise
-    var color_2 = pink
+    var color_turquoise = turquoise
 
     // variable for toggling the polarity
-    var color_toggle = 0
 
     // init image identifiers to null
     var page;
@@ -69,7 +66,6 @@ $(document).ready(function () {
 
         // ensure that all options except the activate canvas button are disabled at start
         $('#canvasButtonCreate').prop('disabled', true);
-        $('#canvasButtonPolarity').prop('disabled', true);
         $('#thickness_range').prop('disabled', true);
         $('#canvasButtonSplit').prop('disabled', true);
         $('#canvasButtonSave').prop('disabled', true);
@@ -79,7 +75,7 @@ $(document).ready(function () {
         width = canvas.get(0).width // retrieve the width of the canvas
         height = canvas.get(0).height // retrieve the width of the canvas
 
-        // set red as default color; used for the control points
+        // reset red as default color; used for the control points
         ctx.fillStyle = '#FF0000';
 
         // reset activation button
@@ -118,7 +114,6 @@ $(document).ready(function () {
         } else {
             // disable all options except the activate canvas button
             $('#canvasButtonCreate').prop('disabled', true);
-            $('#canvasButtonPolarity').prop('disabled', true);
             $('#thickness_range').prop('disabled', true);
             $('#canvasButtonSplit').prop('disabled', true);
             $('#canvasButtonSave').prop('disabled', true);
@@ -161,25 +156,6 @@ $(document).ready(function () {
         }
     })
 
-    // switch the polarity
-    $('#canvasButtonPolarity').on('click', function () {
-        ctx.restore() // restore default settings
-        split_mask = false; // turn of eraser
-        // switch the colors based on the toggle value
-        if (color_toggle == 0) {
-            color_1 = pink
-            color_2 = turquoise
-            color_toggle = 1
-        } else if (color_toggle == 1) {
-            color_1 = turquoise
-            color_2 = pink
-            color_toggle = 0
-        }
-        // redraw the curve
-        // do not sample new points along the line
-        fill_clip(color_1, color_2, thickness, sample = false)
-    });
-
     // create the mask based on the drawn spline
     $('#canvasButtonCreate').on('click', function () {
         ctx.restore() // restore default settings
@@ -188,14 +164,12 @@ $(document).ready(function () {
 
         if (!(pointsQBez.length > 0)) {
             // sample points along splines and draw the mask
-            fill_clip(color_1, color_2, thickness, sample = true)
+            fill_clip(color_turquoise, thickness, sample = true)
         } else {
             // draw the mask, reuse sampled points
-            fill_clip(color_1, color_2, thickness, sample = false)
+            fill_clip(color_turquoise, thickness, sample = false)
         }
-
         // activate all options for manipulating and saving the mask
-        $('#canvasButtonPolarity').prop('disabled', false);
         $('#thickness_range').prop('disabled', false);
         $('#canvasButtonSplit').prop('disabled', false);
         $('#canvasButtonSave').prop('disabled', false);
@@ -293,87 +267,81 @@ $(document).ready(function () {
         };
     }
 
-    // converts the mask line in to a volume mask with polarity indication
-    function fill_clip(color_1, color_2, thickness, sample = false) {
+    
+    function fill_clip(color_turquoise, thickness, sample = false) {
 
-        clear_canvas() // clear the canvas
-        ctx.beginPath() // init new path
-
-        pl = points.length // retrieve length of points list 
-
-        // if the points list contains more then two points
+        clear_canvas(); // clear the canvas
+        ctx.beginPath(); // init new path
+    
+        let pl = points.length; // retrieve length of points list 
+    
+        // if the points list contains more than two points
         if (pl > 2) {
-
+            let ax, ay, bx, by, cx, cy;
+    
             // sample lines along the created quadratic curve
             if (sample) {
-                ax = points[0].x // retrieve start point x
-                ay = points[0].y // retrieve start point y
+                ax = points[0].x; // retrieve start point x
+                ay = points[0].y; // retrieve start point y
+    
                 // iterate over all intermediate points
-                for (i = 1; i < pl - 2; i++) {
-
-                    cx = points[i].x
-                    cy = points[i].y
-                    bx = (points[i].x + points[i + 1].x) / 2
-                    by = (points[i].y + points[i + 1].y) / 2
-
+                for (let i = 1; i < pl - 2; i++) {
+                    cx = points[i].x;
+                    cy = points[i].y;
+                    bx = (points[i].x + points[i + 1].x) / 2;
+                    by = (points[i].y + points[i + 1].y) / 2;
+    
                     // sample the current line segment
                     // the number of samples per line segment depends on the length of the segment
-                    plotQBez(pointsQBez, Math.floor(Math.abs(ax - bx) + Math.abs(ay - by)), ax, ay, cx, cy, bx, by)
-
-                    ax = bx
-                    ay = by
+                    plotQBez(pointsQBez, Math.floor(Math.abs(ax - bx) + Math.abs(ay - by)), ax, ay, cx, cy, bx, by);
+    
+                    ax = bx;
+                    ay = by;
                 }
+    
                 // sample the last line segment
-                bx = points[pl - 1].x
-                by = points[pl - 1].y
-                cx = points[pl - 2].x
-                cy = points[pl - 2].y
+                bx = points[pl - 1].x;
+                by = points[pl - 1].y;
+                cx = points[pl - 2].x;
+                cy = points[pl - 2].y;
+    
                 // sample the last line segment
                 // the number of samples per line segment depends on the length of the segment
-                plotQBez(pointsQBez, Math.floor(Math.abs(ax - bx) + Math.abs(ay - by)), ax, ay, cx, cy, bx, by)
+                plotQBez(pointsQBez, Math.floor(Math.abs(ax - bx) + Math.abs(ay - by)), ax, ay, cx, cy, bx, by);
             }
-
+    
             ctx.save(); // save the current settings
-
+    
             let region_1 = new Path2D(); // define new region
-
+    
             // for every point that was sampled draw a an ellipse with the point at its center
-            for (j = 0; j < pointsQBez.length; j++) {
+            for (let j = 0; j < pointsQBez.length; j++) {
                 // the normal aspect ratio of a html5 canvas is 2/1 
                 // since we have equal width and height, y is distorted by factor 2
-                region_1.moveTo(pointsQBez[j].x + thickness, pointsQBez[j].y) // move to next sampled point
-                region_1.ellipse(pointsQBez[j].x, pointsQBez[j].y, thickness, Math.floor(thickness / 2), 0, 0, Math.PI * 2) // draw the ellipse
+                region_1.moveTo(pointsQBez[j].x + thickness, pointsQBez[j].y); // move to next sampled point
+                region_1.ellipse(pointsQBez[j].x, pointsQBez[j].y, thickness, Math.floor(thickness / 2), 0, 0, Math.PI * 2); // draw the ellipse
             }
+    
             // create the region as clipping region
-            ctx.clip(region_1)
-
-            // set the first color
-            ctx.fillStyle = color_1;
-            ctx.strokeStyle = color_1;
-
-            // draw a rectangle over the whole canvas and fill with first color - will only fill the clipping region
+            ctx.clip(region_1);
+    
+            // set the color
+            ctx.fillStyle = color_turquoise;
+            ctx.strokeStyle = color_turquoise;
+    
+            // draw a rectangle over the whole canvas and fill with the color - will only fill the clipping region
             ctx.rect(0, 0, canvas.get(0).width, canvas.get(0).height);
-            ctx.fill()
-
-            // set the second color
-            ctx.fillStyle = color_2;
-            ctx.strokeStyle = color_2
-
-            // draw a closed shape between the mask and the wall
-            draw_quad_line(points, lineWidth = 1, draw_points = false, close_path = true)
-
-            // fill the closed shape with the second color - will only fill the clipping region with in the closed shape
-            ctx.fill()
+            ctx.fill();
+    
             ctx.restore();
-
-        }
-        else {
-            console.log('A mask needs at least 3 points')
+        } else {
+            console.log('A mask needs at least 3 points');
         }
     };
+    
 
     // create a closed path between the mask path and the wall 
-    function draw_quad_line(points, lineWidth = 1, draw_points = true, close_path = false) {
+    function draw_quad_line(points, lineWidth = 1, draw_points = true) {
         ctx.beginPath()
         ctx.lineWidth = lineWidth;
         ctx.moveTo((points[0].x), points[0].y);
@@ -405,130 +373,8 @@ $(document).ready(function () {
             ctx.fillRect(points[i + 1].x, points[i + 1].y, 2, 2)
         }
 
-        // close the path with the canvas boundary to clip the path in to two and apply the color
-        if (close_path) {
-            pl = points.length - 1
+        ctx.stroke();
 
-            // intersection with it self inside the canvas
-            line_intersection = line_intersect(points[pl - 1].x, points[pl - 1].y, points[pl].x, points[pl].y, points[1].x, points[1].y, points[0].x, points[0].y)
-            if (!line_intersection) {
-                // intersection with boundary
-                intersection_end = intersection(points[pl - 1].x, points[pl - 1].y, points[pl].x, points[pl].y)
-                intersection_start = intersection(points[1].x, points[1].y, points[0].x, points[0].y)
-                close_intersection(intersection_start, intersection_end)
-                ctx.closePath()
-            } else {
-                ctx.lineTo(line_intersection.x, line_intersection.y)
-                ctx.lineTo(points[0].x, points[0].y)
-                ctx.closePath()
-            }
-        }
-
-        if (!close_path) {
-            ctx.stroke();
-        }
-    }
-
-    function close_intersection(int_start, int_end) {
-        // draw line to intersection of the end path with the border
-        ctx.lineTo(int_end.x, int_end.y)
-
-        if (int_start.d == int_end.d) {
-            ctx.lineTo(int_start.x, int_start.y) // if both ends go through the same boarder
-        } else if (int_start.d == 'bot' && int_end.d == 'top') {
-            ctx.lineTo(0, 0) // top left corner
-            ctx.lineTo(0, height) // bottom left corner
-            ctx.lineTo(int_start.x, int_start.y) // intersection
-        } else if (int_start.d == 'top' && int_end.d == 'bot') {
-            ctx.lineTo(0, height) // bottom left corner
-            ctx.lineTo(0, 0) // top left corner
-            ctx.lineTo(int_start.x, int_start.y) // intersection
-        } else if (int_start.d == 'right' && int_end.d == 'left') {
-            ctx.lineTo(0, 0) // top left corner
-            ctx.lineTo(width, 0) // top right corner
-            ctx.lineTo(int_start.x, int_start.y) // intersection
-        } else if (int_start.d == 'left' && int_end.d == 'right') {
-            ctx.lineTo(width, 0) // top right corner
-            ctx.lineTo(0, 0) // top left corner
-            ctx.lineTo(int_start.x, int_start.y) // intersection
-        } else if (int_start.d == 'top' && int_end.d == 'right' || int_start.d == 'right' && int_end.d == 'top') {
-            ctx.lineTo(width, 0) // top right corner
-            ctx.lineTo(int_start.x, int_start.y) // intersection
-        } else if (int_start.d == 'top' && int_end.d == 'left' || int_start.d == 'left' && int_end.d == 'top') {
-            ctx.lineTo(0, 0) // top left corner
-            ctx.lineTo(int_start.x, int_start.y) // intersection
-        } else if (int_start.d == 'bot' && int_end.d == 'right' || int_start.d == 'right' && int_end.d == 'bot') {
-            ctx.lineTo(width, height) // top right corner
-            ctx.lineTo(int_start.x, int_start.y) // intersection
-        } else if (int_start.d == 'bot' && int_end.d == 'left' || int_start.d == 'left' && int_end.d == 'bot') {
-            ctx.lineTo(0, height) // top right corner
-            ctx.lineTo(int_start.x, int_start.y) // intersection
-        }
-        // close the path by drawing line to the start point of the path
-        ctx.lineTo(points[0].x, points[0].y)
-
-    }
-
-    function intersection(x1, y1, x2, y2) {
-        m = slope(x1, x2, y1, y2)
-        b = offset(x1, y1, m)
-
-        // x1---->x2
-        if (x2 > x1) {
-
-            // intersection with the top border 
-            if (y2 < y1) {
-                x = (0 - b) / m
-                if (x <= width && x >= 0) {
-                    return { x: x, y: 0, d: 'top' }
-                }
-            }
-
-            // intersection with bottom border
-            if (y2 > y1) {
-                x = (height - b) / m
-                if (x <= width && x >= 0) {
-                    return { x: x, y: height, d: 'bot' }
-                }
-            }
-
-            // intersection with the right border
-            y = width * m + b
-            if (y <= height && y >= 0) {
-                return { x: width, y: y, d: 'right' }
-            }
-        } else {
-            // intersection with the top border 
-            if (y2 < y1) {
-                x = (0 - b) / m
-                if (x <= width && x >= 0) {
-                    return { x: x, y: 0, d: 'top' }
-                }
-            }
-            // intersection with bottom border
-            if (y2 > y1) {
-                x = (height - b) / m
-                if (x <= width && x >= 0) {
-                    return { x: x, y: height, d: 'bot' }
-                }
-            }
-            // intersection with the left border
-            y = 0 * m + b
-            if (y <= height && y >= 0) {
-                return { x: 0, y: y, d: 'left' }
-            }
-
-        }
-
-    }
-
-    function slope(startX, endX, startY, endY) {
-        // adding EPSILON to avoid division through zero
-        return (endY - startY) / ((endX - startX) + Number.EPSILON)
-    }
-
-    function offset(x, y, m) {
-        return (y - x * m)
     }
 
     function _getQBezierValue(t, p1, p2, p3) {
@@ -552,53 +398,5 @@ $(document).ready(function () {
         pointsQBez.push({ x: Bx, y: By });
         return (pointsQBez);
     };
-
-    // line intercept math by Paul Bourke http://paulbourke.net/geometry/pointlineplane/
-    // Determine the intersection point of two line segments
-    // Return FALSE if the lines don't intersect
-    function line_intersect(x1, y1, x2, y2, x3, y3, x4, y4) {
-
-        // Check if none of the lines are of length 0
-        if ((x1 === x2 && y1 === y2) || (x3 === x4 && y3 === y4)) {
-            return false
-        }
-
-        denominator = ((y4 - y3) * (x2 - x1) - (x4 - x3) * (y2 - y1))
-        // Lines are parallel
-        if (denominator === 0) {
-            return false
-        }
-
-        let ua = ((x4 - x3) * (y1 - y3) - (y4 - y3) * (x1 - x3)) / denominator
-        let ub = ((x2 - x1) * (y1 - y3) - (y2 - y1) * (x1 - x3)) / denominator
-
-        // is the intersection along the segments
-        if (ua < 0 || ua > 1 || ub < 0 || ub > 1) {
-            return false
-        }
-
-        // Return a object with the x and y coordinates of the intersection
-        let x = x1 + ua * (x2 - x1)
-        let y = y1 + ua * (y2 - y1)
-
-        // check if intersection is inside boundaries
-        if ((x > 0) && (x < width) && ((y > 0) && (y < height))) {
-            // only return the intersection if it is inside of the curve
-            if ((x > x2) && (x > x4)) {
-                if ((x2 > x1) && (x4 > x3)) {
-                    return { x: x, y: y }
-                } else {
-                    return false
-                }
-            } else if ((x < x2) && (x < x4)) {
-                if ((x2 < x1) && (x4 < x3)) {
-                    return { x: x, y: y }
-                } else {
-                    return false
-                }
-            }
-            return false
-        }
-    }
 
 });

--- a/synanno/static/draw_module.js
+++ b/synanno/static/draw_module.js
@@ -24,17 +24,35 @@ $(document).ready(function () {
             $('#imgDetails-EM').addClass(label.toLowerCase());
             $('#imgDetails-EM').attr('src', data_json.EM + '/' + data_json.Middle_Slice + '.png');
 
-            if (data.custom_mask_path === null) {
-                $('#imgDetails-EM-GT').addClass('d-none');
+            // curve mask
+            if (data.custom_mask_path_curve === null) {
+                $('#imgDetails-EM-GT-curve').addClass('d-none');
             } else {
-                $(new Image()).attr('src', data.custom_mask_path + '?' + Date.now()).load(function () {
-                    $('#imgDetails-EM-GT').attr('src', this.src);
+                $(new Image()).attr('src', data.custom_mask_path_curve + '?' + Date.now()).load(function () {
+                    $('#imgDetails-EM-GT-curve').attr('src', this.src);
                 });
-                $('#imgDetails-EM-GT').removeClass('d-none');
+                $('#imgDetails-EM-GT-curve').removeClass('d-none');
             }
 
+            // pre-synaptic coordinate mask
+            if (data.custom_mask_path_pre === null) {
+                $('#imgDetails-EM-GT-circlePre').addClass('d-none');
+            } else {
+                $(new Image()).attr('src', data.custom_mask_path_pre + '?' + Date.now()).load(function () {
+                    $('#imgDetails-EM-GT-circlePre').attr('src', this.src);
+                });
+                $('#imgDetails-EM-GT-circlePre').removeClass('d-none');
+            }
 
-            $('#detailsModal').modal('show');
+            // post-synaptic coordinate mask
+            if (data.custom_mask_path_post === null) {
+                $('#imgDetails-EM-GT-circlePost').addClass('d-none');
+            } else {
+                $(new Image()).attr('src', data.custom_mask_path_post + '?' + Date.now()).load(function () {
+                    $('#imgDetails-EM-GT-circlePost').attr('src', this.src);
+                });
+                $('#imgDetails-EM-GT-circlePost').removeClass('d-none');
+            }
 
             // update the range slider
             $('#rangeSlices').attr('min', data.range_min);
@@ -74,7 +92,29 @@ $(document).ready(function () {
     // with in the modal view retrieve the instance specific data
     // to switch between the slices 
     $('#rangeSlices').on('input', function () {
-        // get the curren slice slice index
+
+        // set the visibility of the canvases to hidden
+        // this will trigger the deletion of the canvas
+        $('canvas.curveCanvas').addClass('d-none')
+        $('canvas.circleCanvasPre').addClass('d-none')
+        $('canvas.circleCanvasPost').addClass('d-none')
+
+        // reset all buttons
+        $('#canvasButtonPreCRD').text('Pre-Synaptic CRD');
+        $('#canvasButtonPostCRD').text('Post-Synaptic CRD');
+        $('#canvasButtonPreCRD').prop('disabled', false);
+        $('#canvasButtonPostCRD').prop('disabled', false);
+
+        // reset the draw mask button
+        $('#canvasButtonDrawMask').text('Draw Mask');
+        $('#canvasButtonDrawMask').prop('disabled', false);
+
+        // disable all options except the activate canvas button
+        $('#canvasButtonFill').prop('disabled', true);
+        $('#canvasButtonSplit').prop('disabled', true);
+        $('#canvasButtonSave').prop('disabled', true);
+
+        // get the current slice slice index
         viewed_instance_slice = $(this).val();
         // update the appropriate attribute to be used by the draw.js script
         $(this).data('viewed_instance_slice', viewed_instance_slice);
@@ -101,13 +141,34 @@ $(document).ready(function () {
             data_json = JSON.parse(data.data);
             $('#imgDetails-EM').attr('src', data_json.EM + '/' + viewed_instance_slice + '.png');
 
-            if (data.custom_mask_path === null) {
-                $('#imgDetails-EM-GT').addClass('d-none');
+            // curve mask
+            if (data.custom_mask_path_curve === null) {
+                $('#imgDetails-EM-GT-curve').addClass('d-none');
             } else {
-                $(new Image()).attr('src', data.custom_mask_path + '?' + Date.now()).load(function () {
-                    $('#imgDetails-EM-GT').attr('src', this.src);
+                $(new Image()).attr('src', data.custom_mask_path_curve + '?' + Date.now()).load(function () {
+                    $('#imgDetails-EM-GT-curve').attr('src', this.src);
                 });
-                $('#imgDetails-EM-GT').removeClass('d-none');
+                $('#imgDetails-EM-GT-curve').removeClass('d-none');
+            }
+
+            // pre-synaptic coordinate mask
+            if (data.custom_mask_path_pre === null) {
+                $('#imgDetails-EM-GT-circlePre').addClass('d-none');
+            } else {
+                $(new Image()).attr('src', data.custom_mask_path_pre + '?' + Date.now()).load(function () {
+                    $('#imgDetails-EM-GT-circlePre').attr('src', this.src);
+                });
+                $('#imgDetails-EM-GT-circlePre').removeClass('d-none');
+            }
+
+            // post-synaptic coordinate mask
+            if (data.custom_mask_path_post === null) {
+                $('#imgDetails-EM-GT-circlePost').addClass('d-none');
+            } else {
+                $(new Image()).attr('src', data.custom_mask_path_post + '?' + Date.now()).load(function () {
+                    $('#imgDetails-EM-GT-circlePost').attr('src', this.src);
+                });
+                $('#imgDetails-EM-GT-circlePost').removeClass('d-none');
             }
         });
 
@@ -141,7 +202,9 @@ $(document).ready(function () {
 
     // ensure that the canvas is depicted when returning to the 2D view
     $('#back_to_2d').on('click', function(){
-        $('canvas.coveringCanvas').removeClass('d-none') // change the visibility of the canvas
+        $('canvas.curveCanvas').removeClass('d-none') // change the visibility of the canvas
+        // TODO if I check the ng before drawing any thing we will see the picture logo instead of the canvas
+        // Have to also check this logic for the circle canvas
     });
 
     $('#review_bbox').click(async function (e) {
@@ -164,7 +227,7 @@ $(document).ready(function () {
 
     $('#save_bbox').click(function () {
         // update the bb information with the manuel corrections and pass them to the backend
-        // trigger the processing/save to Json process in the backend
+        // trigger the processing/save to the pandas df in the backend
         $.ajax({
             url: '/ng_bbox_fp_save',
             type: 'POST',

--- a/synanno/static/style.css
+++ b/synanno/static/style.css
@@ -100,18 +100,24 @@
   .outsideWrapper{ 
       margin: auto;
       width:384px; height:384px;}
+
   .insideWrapper{ 
       width:100%; height:100%; 
       position:relative;}
+      
   .coveredImage{ 
       width:100%; height:100%; 
       position:absolute; top:0px; left:0px;
-  }
-  .coveringCanvas{ 
-      width:100%; height:100%; 
-      position:absolute; top:0px; left:0px;
+      pointer-events: none;
+      z-index: 0;
   }
 
+  .curveCanvas, .circleCanvasPre, .circleCanvasPost {
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
+  
 /* css for the open data form */
   .coordinate-container{
     display: flex;

--- a/synanno/templates/draw.html
+++ b/synanno/templates/draw.html
@@ -38,9 +38,16 @@
             {% for image in images %}
 
             {% set z1, z2, x1, x2, y1, y2 = image.Adjusted_Bbox %}
-            {% set custom_mask_name = 'idx_' ~ image.Image_Index ~  '_ms_' ~ image.Middle_Slice ~ '_cor_' ~z1~ '_' ~z2~ '_' ~x1~ '_' ~x2~ '_' ~y1~ '_' ~y2 ~ '.png' %}
-            {% set custom_mask_path_check =  './synanno/static/custom_masks/' ~ custom_mask_name %}
-            {% set custom_mask_path_load =  '/static/custom_masks/' ~ custom_mask_name %}
+            {% set custom_base_path = 'idx_' ~ image.Image_Index ~  '_slice_' ~ image.Middle_Slice ~ '_cor_' ~z1~ '_' ~z2~ '_' ~x1~ '_' ~x2~ '_' ~y1~ '_' ~y2 ~ '.png' %}
+            {% set custom_mask_name_curve = 'curve_' ~ custom_base_path %}
+            {% set custom_mask_name_circle_pre = 'circlePre_' ~ custom_base_path %}
+            {% set custom_mask_name_circle_post = 'circlePost_' ~ custom_base_path %}
+            {% set custom_mask_path_check_curve =  './synanno/static/custom_masks/' ~ custom_mask_name_curve %}
+            {% set custom_mask_path_check_circle_pre =  './synanno/static/custom_masks/' ~ custom_mask_name_circle_pre %}
+            {% set custom_mask_path_check_circle_post =  './synanno/static/custom_masks/' ~ custom_mask_name_circle_post %}
+            {% set custom_mask_path_load_curve =  '/static/custom_masks/' ~ custom_mask_name_curve %}
+            {% set custom_mask_path_load_circle_pre =  '/static/custom_masks/' ~ custom_mask_name_circle_pre %}
+            {% set custom_mask_path_load_circle_post =  '/static/custom_masks/' ~ custom_mask_name_circle_post %}
 
             <div class="card border rounded card-body card-body-proof-read text-center"
                 style="border-width:4px !important;" id="id_error-{{image.Page}}_{{image.Image_Index}}">
@@ -49,13 +56,26 @@
                     page="{{ image.Page }}" data_id="{{ image.Image_Index }}" view_style="{{ view_style }}"
                     label="{% if image.Label == 'Correct' %}Correct{% elif image.Label == 'Incorrect'%}Incorrect{% elif image.Label == 'Unsure'%}Unsure{% endif %}">
                     <div class="main-image-categorize">
+                        <!-- In case of a FN we depict we use the source image also as the target to act as placholder -->
                         {% if image.Error_Description != "False Negatives"%}
-                        <img id="imgEM-GT-{{image.Page}}-{{image.Image_Index}}" class="img_categorize"
-                            src="{% if os.path.exists(custom_mask_path_check) %} {{custom_mask_path_load}} {% else %} {{ image.GT ~ '/' ~ image.Middle_Slice ~ '.png'}} {% endif %}"
+                        <img id="img-target-curve-{{image.Page}}-{{image.Image_Index}}" class="img_categorize"
+                            src="{% if os.path.exists(custom_mask_path_check_curve) %} {{custom_mask_path_load_custom_mask_path_check_curve}} {% else %} {{ image.GT ~ '/' ~ image.Middle_Slice ~ '.png'}} {% endif %}"
+                            width="64px" height="64px" style="opacity: 0.5; ">
+                        <img id="img-target-circlePre-{{image.Page}}-{{image.Image_Index}}" class="img_categorize d-none"
+                            src="{% if os.path.exists(custom_mask_path_check_circle_pre) %} {{custom_mask_path_load_custom_mask_path_check_circle_pre}} {% else %} {{ image.GT ~ '/' ~ image.Middle_Slice ~ '.png'}} {% endif %}"
+                            width="64px" height="64px" style="opacity: 0.5; ">
+                        <img id="img-target-circlePost-{{image.Page}}-{{image.Image_Index}}" class="img_categorize d-none"
+                            src="{% if os.path.exists(custom_mask_path_check_circle_post) %} {{custom_mask_path_load_custom_mask_path_check_circle_post}} {% else %} {{ image.GT ~ '/' ~ image.Middle_Slice ~ '.png'}} {% endif %}"
                             width="64px" height="64px" style="opacity: 0.5; ">
                         {% else %}
-                        <img id="imgEM-GT-{{image.Page}}-{{image.Image_Index}}" class="img_categorize"
-                            src="{% if os.path.exists(custom_mask_path_check) %} {{custom_mask_path_load}} {% else %} {{ image.EM ~ '/' ~ image.Middle_Slice ~ '.png'}} {% endif %}"
+                        <img id="img-target-curve-{{image.Page}}-{{image.Image_Index}}" class="img_categorize"
+                            src="{% if os.path.exists(custom_mask_path_check_curve) %} {{custom_mask_path_load_custom_mask_path_check_curve}} {% else %} {{ image.EM ~ '/' ~ image.Middle_Slice ~ '.png'}} {% endif %}"
+                            width="64px" height="64px" style="opacity: 0.5; ">
+                        <img id="img-target-circlePre-{{image.Page}}-{{image.Image_Index}}" class="img_categorize d-none"
+                            src="{% if os.path.exists(custom_mask_path_check_circle_pre) %} {{custom_mask_path_load_custom_mask_path_check_circle_pre}} {% else %} {{ image.EM ~ '/' ~ image.Middle_Slice ~ '.png'}} {% endif %}"
+                            width="64px" height="64px" style="opacity: 0.5; ">
+                        <img id="img-target-circlePost-{{image.Page}}-{{image.Image_Index}}" class="img_categorize d-none"
+                            src="{% if os.path.exists(custom_mask_path_check_circle_post) %} {{custom_mask_path_load_custom_mask_path_check_circle_post}} {% else %} {{ image.EM ~ '/' ~ image.Middle_Slice ~ '.png'}} {% endif %}"
                             width="64px" height="64px" style="opacity: 0.5; ">
                         {% endif %}
                         <img id="imgGT-{{image.Page}}-{{image.Image_Index}}" class="img_categorize" data-image_base_path="{{ image.EM }}"

--- a/synanno/templates/draw_modal.html
+++ b/synanno/templates/draw_modal.html
@@ -11,13 +11,27 @@
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body mx-auto">
+                <div class="center">
+                    <div class="row justify-content-center">
+                        <div class="col-md-12 text-center">
+                            <form>
+                                <button type="button" class="btn btn-secondary" id="canvasButtonPreCRD">Pre-Synaptic CRD</button>
+                                <button type="button" class="btn btn-secondary" id="canvasButtonPostCRD">Post-Synaptic CRD</button>
+                            </form>
+                        </div>
+                    </div>
+                </div>
                 <div class="d-flex justify-content-center">
                     <div id="cardDetails" class="card border-0 p-1">
                         <div class="outsideWrapper border rounded" style="border-width:4px !important;">
                             <div class="insideWrapper">
                                 <img id="imgDetails-EM" class="coveredImage" src="">
-                                <img id="imgDetails-EM-GT" class="coveredImage d-none" src="">
-                                <canvas class="coveringCanvas d-none"></canvas>
+                                <img id="imgDetails-EM-GT-curve" class="coveredImage d-none" style="opacity: 0.5; " src="">
+                                <img id="imgDetails-EM-GT-circlePre" class="coveredImage d-none" style="opacity: 0.5; " src="">
+                                <img id="imgDetails-EM-GT-circlePost" class="coveredImage d-none" style="opacity: 0.5; " src="">
+                                <canvas class="curveCanvas d-none"></canvas>
+                                <canvas class="circleCanvasPre d-none"></canvas>
+                                <canvas class="circleCanvasPost d-none"></canvas>
                             </div>
                         </div>
                     </div>
@@ -27,11 +41,10 @@
                         <div class="col-md-12 text-center">
                             <form>
                                 <button type="button" class="btn btn-secondary"
-                                    id="canvasButtonActivate">Activate</button>
-                                <button type="button" class="btn btn-secondary" id="canvasButtonCreate">Fill</button>
+                                id="canvasButtonDrawMask">Draw Mask</button>
+                                <button type="button" class="btn btn-secondary" id="canvasButtonFill">Fill</button>
                                 <button type="button" class="btn btn-secondary" id="canvasButtonSplit">Revise</button>
-                                <button type="button" class="btn btn-secondary" id="canvasButtonSave"
-                                    data-bs-dismiss="modal">Save</button>
+                                <button type="button" class="btn btn-secondary" id="canvasButtonSave">Save</button>
                             </form>
                         </div>
                     </div>

--- a/synanno/templates/draw_modal.html
+++ b/synanno/templates/draw_modal.html
@@ -29,8 +29,6 @@
                                 <button type="button" class="btn btn-secondary"
                                     id="canvasButtonActivate">Activate</button>
                                 <button type="button" class="btn btn-secondary" id="canvasButtonCreate">Fill</button>
-                                <button type="button" class="btn btn-secondary"
-                                    id="canvasButtonPolarity">Switch</button>
                                 <button type="button" class="btn btn-secondary" id="canvasButtonSplit">Revise</button>
                                 <button type="button" class="btn btn-secondary" id="canvasButtonSave"
                                     data-bs-dismiss="modal">Save</button>

--- a/synanno/templates/draw_modal_fp.html
+++ b/synanno/templates/draw_modal_fp.html
@@ -20,7 +20,7 @@
             <div class="col">
               <button id="review_bbox" class="btn btn-primary" type="button" data-bs-target="#drawModalFPSave"
                 data-bs-toggle="modal">Review</button>                
-              <button id="back_to_2d"class="btn btn-primary" data-bs-target="#drawModal" data-bs-toggle="modal"
+              <button id="back_to_2d" class="btn btn-primary" data-bs-target="#drawModal" data-bs-toggle="modal"
               data-bs-dismiss="modal">Back to 2D view</button>
             </div>
           </div>

--- a/synanno/templates/draw_modal_fp_save.html
+++ b/synanno/templates/draw_modal_fp_save.html
@@ -66,8 +66,7 @@
 
 
                 <div class="modal-footer">
-                    <button id="save_bbox" class="btn btn-primary" data-bs-target="#detailsModal" data-bs-toggle="modal"
-                        data-bs-dismiss="modal">Save</button>
+                    <button id="save_bbox" class="btn btn-primary" data-bs-dismiss="modal">Save</button>
                 </div>
 
 

--- a/synanno/templates/opendata.html
+++ b/synanno/templates/opendata.html
@@ -119,8 +119,8 @@
     <div class="mb-1"></div>
 
     <label for="formGroupExampleInput" class="form-label">Instance crop size (in px)</label>
-    <input type="number" id="cropsize_x" placeholder="142" name="crop_size_x" value=142> 
-    <input type="number" id="cropsize_y" placeholder="142" name="crop_size_y" value=142> 
+    <input type="number" id="cropsize_x" placeholder="256" name="crop_size_x" value=256> 
+    <input type="number" id="cropsize_y" placeholder="256" name="crop_size_y" value=256> 
     <input type="number" id="cropsize_z" placeholder="16" name="crop_size_z" value=16> 
 
     <p class="mt-4">


### PR DESCRIPTION
Resolves #67

This PR implements the newly agreed-upon mask layout. Specifically, the changes introduced are:

- **Monochrome Segmentation Mask**: The custom-drawn masks have been simplified to a monochrome layout in accordance with the H01 layout. 
  
- **Synapse Points Visualization**: Points are now sourced from the materialization tables. Pre-synaptic pints are colored green, and post-synaptic points are collared blue. For ease of distinction, these points will be brightly colored on their respective slices and will appear in a dimmer shade on all other slices.
  
- **Enhanced Manual Drawing**: Users now have the flexibility to set synapse points on any slice. This change caters to scenarios where the pre-synaptic and post-synaptic synapses are not on the same slice.

**Commits**:
1. Reduced the custom-drawn masks to a monochrome layout.
2. Updated the custom mask drawing to enable slice-wise coordinate selection for both pre and post-synapse.

Feedback and further suggestions are welcome.
