### PR TITLE
Enhance Visual Clarity in Draw View by Distinctly Highlighting Pre/Post-Synaptic ID Coordinates

### DIFF
--- a/synanno/__init__.py
+++ b/synanno/__init__.py
@@ -76,6 +76,11 @@ def configure_app():
     app.df_metadata = pd.DataFrame(columns=app.columns)
     app.materialization = {}
 
+    app.pre_id_color_main = (0, 255, 0)
+    app.pre_id_color_sub = (200, 255, 200)
+    app.post_id_color_main = (0, 0, 255)
+    app.post_id_color_sub = (200, 200, 255)
+
     return app
 
 

--- a/synanno/backend/processing.py
+++ b/synanno/backend/processing.py
@@ -459,8 +459,8 @@ def _process_instance(item: dict, img_dir_instance: str, syn_dir_instance: str) 
         pre_pt_y,
         pre_pt_z,
         radius=10,
-        color_1=(0, 255, 0),
-        color_2=(200, 255, 200),
+        color_main=app.pre_id_color_main,
+        color_sub=app.pre_id_color_sub,
         layout=coord_order,
     )
     vis_label = draw_cylinder(
@@ -469,8 +469,8 @@ def _process_instance(item: dict, img_dir_instance: str, syn_dir_instance: str) 
         post_pt_y,
         post_pt_z,
         radius=10,
-        color_1=(0, 0, 255),
-        color_2=(200, 200, 255),
+        color_main=app.post_id_color_main,
+        color_sub=app.post_id_color_sub,
         layout=coord_order,
     )
 

--- a/synanno/backend/utils.py
+++ b/synanno/backend/utils.py
@@ -133,8 +133,8 @@ def draw_cylinder(
     center_y: int,
     center_z: int,
     radius: int,
-    color_1: Tuple[int, int, int],
-    color_2: Tuple[int, int, int],
+    color_main: Tuple[int, int, int],
+    color_sub: Tuple[int, int, int],
     layout: str,
 ) -> np.ndarray:
     """
@@ -146,8 +146,8 @@ def draw_cylinder(
     center_y (int): Y-coordinate of the cylinder center.
     center_z (int): Z-coordinate of the cylinder center.
     radius (int): Radius of the cylinder.
-    color_1 (Tuple[int, int, int]): RGB color of the circle in the center_z layer.
-    color_2 (Tuple[int, int, int]): RGB color of the circles in the other layers.
+    color_main (Tuple[int, int, int]): RGB color of the circle in the center_z layer.
+    color_sub (Tuple[int, int, int]): RGB color of the circles in the other layers.
     layout (str): The layout of the axes, for example, "zyxc".
 
     Returns:
@@ -180,12 +180,12 @@ def draw_cylinder(
                 np.where(mask_cylinder),
                 np.where(mask_cylinder)[1],
             )
-            image[tuple(slice_list)] = color_2
+            image[tuple(slice_list)] = color_sub
         else:
             slice_list[y_index], slice_list[x_index] = (
                 np.where(mask_cylinder),
                 np.where(mask_cylinder)[1],
             )
-            image[tuple(slice_list)] = color_1
+            image[tuple(slice_list)] = color_main
 
     return image

--- a/synanno/routes/categorize.py
+++ b/synanno/routes/categorize.py
@@ -22,9 +22,9 @@ from typing import Dict
 
 
 # global variable defining if instances marked as false positives are directly discarded
-global delete_fns
+global delete_fps
 
-delete_fns = False
+delete_fps = False
 
 
 @app.route("/categorize")
@@ -69,18 +69,18 @@ def pass_flags() -> Dict[str, object]:
         Confirms the successful update to the frontend
     """
 
-    # variable specifying if instances marked as FN are discarded, the default is False
-    global delete_fns
+    # variable specifying if instances marked as FP are discarded, the default is False
+    global delete_fps
 
     # retrieve the frontend data
     flags = request.get_json()["flags"]
-    delete_fns = bool(request.get_json()["delete_fns"])
+    delete_fps = bool(request.get_json()["delete_fps"])
 
     # updated all flags
     for flag in flags:
         page_nr, img_nr, f = dict(flag).values()
         # deleting false positives
-        if f == "falsePositive" and delete_fns:
+        if f == "falsePositive" and delete_fps:
             app.df_metadata.drop(
                 app.df_metadata[
                     (app.df_metadata["Page"] == int(page_nr))

--- a/synanno/routes/manual_annotate.py
+++ b/synanno/routes/manual_annotate.py
@@ -472,6 +472,44 @@ def save_pre_post_coordinates() -> None:
             & (app.df_metadata["Page"] == page),
             "pre_pt_z",
         ] = z
+
+        # get the segmentation folder
+        seg_folder = app.df_metadata.loc[
+            (app.df_metadata["Image_Index"] == data_id)
+            & (app.df_metadata["Page"] == page),
+            "GT",
+        ].values[0]
+
+        # get the instance middle slice
+        middle_slice = app.df_metadata.loc[
+            (app.df_metadata["Image_Index"] == data_id)
+            & (app.df_metadata["Page"] == page),
+            "Middle_Slice",
+        ].values[0]
+
+        # load the slice of the segmentation
+        seg_slice = Image.open(
+            os.path.join(
+                app.root_path, seg_folder.lstrip("/"), str(middle_slice) + ".png"
+            )
+        )
+
+        # set any pixels with value app.pre_id_color_main to pre_id_color_sub
+        seg_slice = np.array(seg_slice)
+
+        # Create a boolean mask where the RGB values of seg_slice match app.pre_id_color_main
+        mask = np.all(seg_slice[:, :, :3] == app.pre_id_color_main, axis=-1)
+
+        # Where the mask is True, set the RGB values to app.pre_id_color_sub
+        seg_slice[mask, :3] = app.pre_id_color_sub
+
+        # save the updated segmentation
+        Image.fromarray(seg_slice).save(
+            os.path.join(
+                app.root_path, seg_folder.lstrip("/"), str(middle_slice) + ".png"
+            )
+        )
+
     elif id == "post":
         app.df_metadata.loc[
             (app.df_metadata["Image_Index"] == data_id)
@@ -488,6 +526,43 @@ def save_pre_post_coordinates() -> None:
             & (app.df_metadata["Page"] == page),
             "post_pt_z",
         ] = z
+
+        # get the segmentation folder
+        seg_folder = app.df_metadata.loc[
+            (app.df_metadata["Image_Index"] == data_id)
+            & (app.df_metadata["Page"] == page),
+            "GT",
+        ].values[0]
+
+        # get the instance middle slice
+        middle_slice = app.df_metadata.loc[
+            (app.df_metadata["Image_Index"] == data_id)
+            & (app.df_metadata["Page"] == page),
+            "Middle_Slice",
+        ].values[0]
+
+        # load the slice of the segmentation
+        seg_slice = Image.open(
+            os.path.join(
+                app.root_path, seg_folder.lstrip("/"), str(middle_slice) + ".png"
+            )
+        )
+
+        # set any pixels with value app.post_id_color_main to post_id_color_sub
+        seg_slice = np.array(seg_slice)
+
+        # Create a boolean mask where the RGB values of seg_slice match app.pre_id_color_main
+        mask = np.all(seg_slice[:, :, :3] == app.post_id_color_main, axis=-1)
+
+        # Where the mask is True, set the RGB values to app.pre_id_color_sub
+        seg_slice[mask, :3] = app.post_id_color_sub
+
+        # save the updated segmentation
+        Image.fromarray(seg_slice).save(
+            os.path.join(
+                app.root_path, seg_folder.lstrip("/"), str(middle_slice) + ".png"
+            )
+        )
     else:
         raise ValueError("id must be pre or post")
 

--- a/synanno/routes/manual_annotate.py
+++ b/synanno/routes/manual_annotate.py
@@ -487,7 +487,7 @@ def save_pre_post_coordinates() -> None:
             "Middle_Slice",
         ].values[0]
 
-        # set the color of the pre instance in the middle slice of the segmentation to gray
+        # set the color of the pre coordinate instance in the middle slice of the segmentation to (128, 128, 128, 0.5)
         # we only have to check the middle slice since it is the only slice of the original masks,
         # that ever gets depicted in the draw view
         # if the instance is not a false negative and the middle slice mask exists
@@ -590,8 +590,4 @@ def save_pre_post_coordinates() -> None:
     else:
         raise ValueError("id must be pre or post")
 
-    return jsonify(
-        {
-            "middle_slice": str(middle_slice),
-        }
-    )
+    return json.dumps({"success": True}), 200, {"ContentType": "application/json"}

--- a/synanno/routes/manual_annotate.py
+++ b/synanno/routes/manual_annotate.py
@@ -506,8 +506,11 @@ def save_pre_post_coordinates() -> None:
             # set any pixels with value app.pre_id_color_main to pre_id_color_sub
             seg_slice = np.array(seg_slice)
 
-            # Create a boolean mask where the RGB values of seg_slice match app.pre_id_color_main
-            mask = np.all(seg_slice[:, :, :3] == app.pre_id_color_main, axis=-1)
+            # Create a boolean mask where the RGB values of seg_slice match app.pre_id_color_main and sub
+            mask_main = np.all(seg_slice[:, :, :3] == app.pre_id_color_main, axis=-1)
+            mask_sub = np.all(seg_slice[:, :, :3] == app.pre_id_color_sub, axis=-1)
+
+            mask = mask_main | mask_sub
 
             # Where the mask is True, set the RGB values to app.pre_id_color_sub
             seg_slice[mask] = (128, 128, 128, 0.5)
@@ -570,7 +573,10 @@ def save_pre_post_coordinates() -> None:
             seg_slice = np.array(seg_slice)
 
             # Create a boolean mask where the RGB values of seg_slice match app.post_id_color_main
-            mask = np.all(seg_slice[:, :, :3] == app.post_id_color_main, axis=-1)
+            mask_main = np.all(seg_slice[:, :, :3] == app.post_id_color_main, axis=-1)
+            mask_sub = np.all(seg_slice[:, :, :3] == app.post_id_color_sub, axis=-1)
+
+            mask = mask_main | mask_sub
 
             # Where the mask is True, set the RGB values to app.post_id_color_sub
             seg_slice[mask] = (128, 128, 128, 0.5)

--- a/synanno/routes/manual_annotate.py
+++ b/synanno/routes/manual_annotate.py
@@ -487,28 +487,37 @@ def save_pre_post_coordinates() -> None:
             "Middle_Slice",
         ].values[0]
 
-        # load the slice of the segmentation
-        seg_slice = Image.open(
+        # set the color of the pre instance in the middle slice of the segmentation to gray
+        # we only have to check the middle slice since it is the only slice of the original masks,
+        # that ever gets depicted in the draw view
+        # if the instance is not a false negative and the middle slice mask exists
+        if os.path.exists(
             os.path.join(
                 app.root_path, seg_folder.lstrip("/"), str(middle_slice) + ".png"
             )
-        )
-
-        # set any pixels with value app.pre_id_color_main to pre_id_color_sub
-        seg_slice = np.array(seg_slice)
-
-        # Create a boolean mask where the RGB values of seg_slice match app.pre_id_color_main
-        mask = np.all(seg_slice[:, :, :3] == app.pre_id_color_main, axis=-1)
-
-        # Where the mask is True, set the RGB values to app.pre_id_color_sub
-        seg_slice[mask, :3] = app.pre_id_color_sub
-
-        # save the updated segmentation
-        Image.fromarray(seg_slice).save(
-            os.path.join(
-                app.root_path, seg_folder.lstrip("/"), str(middle_slice) + ".png"
+        ):
+            # load the slice of the segmentation
+            seg_slice = Image.open(
+                os.path.join(
+                    app.root_path, seg_folder.lstrip("/"), str(middle_slice) + ".png"
+                )
             )
-        )
+
+            # set any pixels with value app.pre_id_color_main to pre_id_color_sub
+            seg_slice = np.array(seg_slice)
+
+            # Create a boolean mask where the RGB values of seg_slice match app.pre_id_color_main
+            mask = np.all(seg_slice[:, :, :3] == app.pre_id_color_main, axis=-1)
+
+            # Where the mask is True, set the RGB values to app.pre_id_color_sub
+            seg_slice[mask] = (128, 128, 128, 0.5)
+
+            # save the updated segmentation
+            Image.fromarray(seg_slice).save(
+                os.path.join(
+                    app.root_path, seg_folder.lstrip("/"), str(middle_slice) + ".png"
+                )
+            )
 
     elif id == "post":
         app.df_metadata.loc[
@@ -541,30 +550,42 @@ def save_pre_post_coordinates() -> None:
             "Middle_Slice",
         ].values[0]
 
-        # load the slice of the segmentation
-        seg_slice = Image.open(
+        # set the color of the pre instance in the middle slice of the segmentation to gray
+        # we only have to check the middle slice since it is the only slice of the original masks,
+        # that ever gets depicted in the draw view
+        # if the instance is not a false negative and the middle slice mask exists
+        if os.path.exists(
             os.path.join(
                 app.root_path, seg_folder.lstrip("/"), str(middle_slice) + ".png"
             )
-        )
-
-        # set any pixels with value app.post_id_color_main to post_id_color_sub
-        seg_slice = np.array(seg_slice)
-
-        # Create a boolean mask where the RGB values of seg_slice match app.pre_id_color_main
-        mask = np.all(seg_slice[:, :, :3] == app.post_id_color_main, axis=-1)
-
-        # Where the mask is True, set the RGB values to app.pre_id_color_sub
-        seg_slice[mask, :3] = app.post_id_color_sub
-
-        # save the updated segmentation
-        Image.fromarray(seg_slice).save(
-            os.path.join(
-                app.root_path, seg_folder.lstrip("/"), str(middle_slice) + ".png"
+        ):
+            # load the slice of the segmentation
+            seg_slice = Image.open(
+                os.path.join(
+                    app.root_path, seg_folder.lstrip("/"), str(middle_slice) + ".png"
+                )
             )
-        )
+
+            # set any pixels with value app.post_id_color_main to post_id_color_sub
+            seg_slice = np.array(seg_slice)
+
+            # Create a boolean mask where the RGB values of seg_slice match app.post_id_color_main
+            mask = np.all(seg_slice[:, :, :3] == app.post_id_color_main, axis=-1)
+
+            # Where the mask is True, set the RGB values to app.post_id_color_sub
+            seg_slice[mask] = (128, 128, 128, 0.5)
+
+            # save the updated segmentation
+            Image.fromarray(seg_slice).save(
+                os.path.join(
+                    app.root_path, seg_folder.lstrip("/"), str(middle_slice) + ".png"
+                )
+            )
     else:
         raise ValueError("id must be pre or post")
 
-    # return success
-    return json.dumps({"success": True}), 200, {"ContentType": "application/json"}
+    return jsonify(
+        {
+            "middle_slice": str(middle_slice),
+        }
+    )

--- a/synanno/static/categorize.js
+++ b/synanno/static/categorize.js
@@ -90,10 +90,30 @@ $(document).ready(function () {
 
   // process the flags: [[pager number, image number, flag], ..., [pager number, image number, flag]]
 
+  // check if one of the flags was set to false positive on click of the submit button
+  $("#submit_button").click(function () {
+    var fp_set = false;
+    $('[id^="id_error_"]').each(function (index) {
+      console.log(index);
+      // show the categorizeModalFPSave modal if true
+      if ($('[id^="falsePositive_"]', $(this)).is(":checked")) {
+        fp_set = true;
+        $("#categorizeModalFPSave").modal("show");
+      }
+    });
+
+    if (!fp_set) {
+      // else show loading screen and process the data
+      $("#progressModal").modal("show");
+      submit_data(false);
+    }
+
+  });
+
   // delete the false positives from the JSON
   $("#dl_fn_yes").click(async function () {
     // show loading screen
-    $("#categorizeModalFNSave").modal("hide");
+    $("#categorizeModalFPSave").modal("hide");
     $("#progressModal").modal("show");
 
     submit_data(true);
@@ -102,7 +122,7 @@ $(document).ready(function () {
   // keep the false positives in the JSON
   $("#dl_fn_no").click(async function () {
     // show loading screen
-    $("#categorizeModalFNSave").modal("hide");
+    $("#categorizeModalFPSave").modal("hide");
     $("#progressModal").modal("show");
 
     submit_data(false);
@@ -117,7 +137,7 @@ $(document).ready(function () {
 });
 
 // process the flags: [[pager number, image number, flag], ..., [pager number, image number, flag]]
-function submit_data(delete_fns) {
+function submit_data(delete_fps) {
   var promise_error = new Promise((resolve, reject) => {
     var flags = [];
     var nr_elements = $('[id^="id_error_"]').length;
@@ -161,7 +181,7 @@ function submit_data(delete_fns) {
       type: "POST",
       contentType: "application/json",
       dataType: "json",
-      data: JSON.stringify({ flags: data, delete_fns: delete_fns }),
+      data: JSON.stringify({ flags: data, delete_fps: delete_fps }),
     });
 
     req.success(function () {

--- a/synanno/static/draw.js
+++ b/synanno/static/draw.js
@@ -391,6 +391,9 @@ $(document).ready(function () {
 
         // reenable the buttons for the pre and post id
         $("#canvasButtonPreCRD, #canvasButtonPostCRD").prop("disabled", false);
+
+        // disable the save, fill and revise button
+        $("#canvasButtonSave, #canvasButtonFill, #canvasButtonSplit").prop("disabled", true);
       }
 
       if (canvas_type === "circlePre" || canvas_type === "circlePost") {

--- a/synanno/static/draw.js
+++ b/synanno/static/draw.js
@@ -402,21 +402,15 @@ $(document).ready(function () {
         // we load the image and add cache breaker in case the mask gets drawn multiple times
         // with out the cache breaker the mask will be updated in the backend, however, the old image will be depicted
         $(new Image())
-          .attr("src", image_path + "?" + Date.now())
-          .load(function () {
-            $(em_target_image).attr("src", this.src);
-          });
-
+        .attr("src", image_path + "?" + Date.now())
+        .load(function () {
+          $(em_target_image).attr("src", this.src);
+        });
 
         last_slice = viewed_instance_slice; // update the last slice for which a mask was drawn
 
         // save the coordinates of the pre and post synaptic CRD
         if (canvas_type == "circlePre" || canvas_type == "circlePost") {
-
-          // force the browser to reload the em_source_image in case the user drew only new id coordinates
-          $(em_source_image).attr("src", $(em_source_image).attr("src") + "?" + Date.now());
-
-
           // send the coordinates to the backend
           id = canvas_type == "circlePre" ? "pre" : "post";
           $.ajax({
@@ -432,10 +426,15 @@ $(document).ready(function () {
               id: id,
             },
           }).done(function (data) {
-            // check success of the request
-            if (data.success) {
-              console.log("Successfully saved " + id + " coordinates");
+            // reload the depicted default middle slice mask incase the we updated the pre or post coordinates
+            // and blurred out the initial pre or post coordinates
+            if (data.middle_slice == viewed_instance_slice) {
+              img_target_curve = "#img-target-curve-" + page + "-" + data_id
+              // reload the current src of em_target_image
+              var current_src = $(img_target_curve).attr("src").trim();
+              $(img_target_curve).attr("src", current_src + "?" + Date.now());
             }
+
           });
         }
 

--- a/synanno/static/draw.js
+++ b/synanno/static/draw.js
@@ -362,7 +362,7 @@ $(document).ready(function () {
     }).done(function (data) {
       data_json = JSON.parse(data.data);
 
-      // only update the circle_pre and circle_post slice number matches that of the latest drawn curve
+      // in case that the pre or post id was updated only update the image if their slice number matches that of the latest drawn curve
       if (
         canvas_type == "curve" ||
         ((canvas_type == "circlePre" || canvas_type == "circlePost") &&
@@ -407,10 +407,16 @@ $(document).ready(function () {
             $(em_target_image).attr("src", this.src);
           });
 
+
         last_slice = viewed_instance_slice; // update the last slice for which a mask was drawn
 
         // save the coordinates of the pre and post synaptic CRD
         if (canvas_type == "circlePre" || canvas_type == "circlePost") {
+
+          // force the browser to reload the em_source_image in case the user drew only new id coordinates
+          $(em_source_image).attr("src", $(em_source_image).attr("src") + "?" + Date.now());
+
+
           // send the coordinates to the backend
           id = canvas_type == "circlePre" ? "pre" : "post";
           $.ajax({

--- a/synanno/templates/categorize.html
+++ b/synanno/templates/categorize.html
@@ -129,8 +129,7 @@
       type="button"
       id="submit_button"
       class="btn btn-primary {{ modenext }}"
-      data-bs-target="#categorizeModalFNSave"
-      data-bs-toggle="modal"
+      data-bs-target="#categorizeModalFPSave"
       >Submit and Finish</a
     >
   </div>
@@ -142,7 +141,7 @@
 <!-- Modal for neuroglancer slice-->
 {% include "annotation_neuro.html" %}
 
-<!-- Modal for FN deletion-->
+<!-- Modal for FP deletion-->
 {% include "categorize_modal_dl_fn.html" %}
 
 <!-- Modal for progress bar-->

--- a/synanno/templates/categorize_modal_dl_fn.html
+++ b/synanno/templates/categorize_modal_dl_fn.html
@@ -2,9 +2,9 @@
       The view lets the user manuly correct the recorded coordinates. -->
 <div
   class="modal fade"
-  id="categorizeModalFNSave"
+  id="categorizeModalFPSave"
   tabindex="-1"
-  aria-labelledby="categorizeModalFNSave"
+  aria-labelledby="categorizeModalFPSave"
   aria-hidden="true"
 >
   <div class="modal-dialog modal-dialog-centered modal-sm">

--- a/synanno/templates/opendata.html
+++ b/synanno/templates/opendata.html
@@ -209,7 +209,6 @@
             id="x1"
             name="x1"
             placeholder="X1 - Default: 0"
-            value="199891"
           />
           <input
             class="coordinate-dims"
@@ -217,7 +216,6 @@
             id="x2"
             name="x2"
             placeholder="X2 - Default: max(X)"
-            value="437848"
           />
           <input
             class="coordinate-dims"
@@ -225,7 +223,6 @@
             id="y1"
             name="y1"
             placeholder="Y1 - Default: 0"
-            value="169018"
           />
           <input
             class="coordinate-dims"
@@ -233,7 +230,6 @@
             id="y2"
             name="y2"
             placeholder="Y2 - Default: max(Y)"
-            value="262596"
           />
           <input
             class="coordinate-dims"
@@ -241,7 +237,6 @@
             id="z1"
             name="z1"
             placeholder="Z1 - Default: 0"
-            value="1280"
           />
           <input
             class="coordinate-dims"
@@ -249,7 +244,6 @@
             id="z2"
             name="z2"
             placeholder="Z2 - Default: max(Z)"
-            value="1536"
           />
         </div>
       </div>


### PR DESCRIPTION
Addresses #79, which outlines how the mix of pre/post-synaptic ID coordinates with the primary mask layer in the drawing mode was causing clarity issues and coordinate setting errors.

### Changes:
Upon adding a new ID, the center mask slice is loaded. Using distinct color cues (green for pre-synaptic and blue for post-synaptic), a mask is generated. This mask grays out the original ID marker, ensuring the new ID marker stands out in its vibrant color, while prior IDs shift to gray for clearer differentiation. In the draw view, the center slice is the default display. Consequently, this graying process is only activated when a user resets the ID without modifying the mask. This behavior stems from the fact that the draw view primarily showcases the center slice unless a custom mask has been crafted, in which case that specific slice takes precedence.

### Benefits:
**Enhanced User Feedback**: Users now receive clear visual indications, streamlining the ID setting process.
**Efficiency**: Avoided potential inefficiencies of adding extra image layers.
**Focused Workflow**: The update bolsters the coordinate editing experience, ensuring smooth user interactions.